### PR TITLE
Add XIV ToDo to the website list

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Name|Description
 [XIV Dev Wiki](https://xiv.dev/)|The deep dark darkness wiki
 [XIV Mod Archive](https://www.xivmodarchive.com/)|Mod archive for FFXIV.
 [XIVStatus](https://xivstatus.com/)|FFXIV server status monitor
+[XIV ToDo](https://xivtodo.com/)|Completion trackers, dashboards, and daily & weekly activities.
 
 ## Web APIs
 Name|Description


### PR DESCRIPTION
This PR adds an entry to the website list for XIV ToDo, which I actively maintain.