### PR TITLE
add xivsim

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Name|Description
 [XIVAPI Browser](https://ffxiv.pf-n.co/xivapi)|An interface for browsing the XIVAPI.
 [XIV Mod Archive](https://www.xivmodarchive.com/)|Mod archive for FFXIV.
 [XIVStatus](https://xivstatus.com/)|FFXIV server status monitor.
+[xivsim](https://www.xivsim.com/)|FFXIV Raid Simulator.
 [XIV ToDo](https://xivtodo.com/)|Completion trackers, dashboards, and daily & weekly activities.
 
 ## Web APIs


### PR DESCRIPTION
[xivsim](https://www.xivsim.com/) is a raid simulator for ffxiv for up to 8 people to simulate specific mechanics, it includes and ever growing number of mechanics and has every major ultimate mechanic (and all P4s Act's)