### PR TITLE
no REST for the weary

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Name|Description
 [gcf-lodestone](https://github.com/ffxiv-teamcraft/gcf-lodestone)|A set of example lodestone parsing functions ready to be deployed to GCF
 [Kal's FFXIV API](https://app.swaggerhub.com/apis-docs/kalilistic/ffxiv-api/)|REST API for lodestone ids and more.
 [Lodestone News](https://documenter.getpostman.com/view/1779678/TzXzDHVk)|REST API for Lodestone news.
-[Thaliak](https://thaliak.xiv.dev/)|Game version/patch tracking site offering a REST API.
+[Thaliak](https://thaliak.xiv.dev/)|Game version/patch tracking site offering a GraphQL API.
 [Universalis](https://universalis.app/)|Crowdsourced market board website and API.
 [XIVAPI](https://xivapi.com/)|Game data API.
 [XIV-Character-Cards](https://github.com/ArcaneDisgea/XIV-Character-Cards)|Character card generator.


### PR DESCRIPTION
Thaliak's REST API is being discontinued later this year in favour of a GraphQL API; updated accordingly.