### PR TITLE
Add XIV Arbitrage: cross-DC market board arbitrage finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Name|Description
 [Toolbox Gaming Space Timeline Planner](https://ff14.toolboxgaming.space/timeline/)|Timeline planner for FFXIV.
 [Universalis](https://universalis.app/)|Crowdsourced market board website and API.
 [Wondrous Tails](https://ffxiv.pf-n.co/wondrous-tails)|Calculator for the Wondrous Tails mini-game.
+[XIV Arbitrage](https://xivarbitrage.projects.blueskye.co.uk/)|Cross-DC market board arbitrage finder. Scans ~10,000 items across NA, EU, and OCE to find price disparities and bargains.
 [xivanalysis](https://xivanalysis.com/)|Automated performance analysis and suggestion platform for Final Fantasy XIV: Shadowbringers.
 [XIVAPI Browser](https://ffxiv.pf-n.co/xivapi)|An interface for browsing the XIVAPI.
 [xivLeve](https://xivleve.org/)|Every hour new easy FFXIV leves! The easiest to buy items from the market board to maximize profit doing levequests.
@@ -100,6 +101,7 @@ Name|Description
 [Lodestone News](https://documenter.getpostman.com/view/1779678/TzXzDHVk)|REST API for Lodestone news.
 [Thaliak](https://thaliak.xiv.dev/)|Game version/patch tracking site offering a GraphQL API.
 [Universalis](https://universalis.app/)|Crowdsourced market board website and API.
+[XIV Arbitrage API](https://xivarbitrage.projects.blueskye.co.uk/api/dc-disparities)|Public REST API for DC price disparities and market bargains. Includes item sale history and discounted listings, with usage monitoring.
 [XIVAPI](https://xivapi.com/)|Game data API.
 [XIV-Character-Cards](https://github.com/ArcaneDisgea/XIV-Character-Cards)|Character card generator.
 [XIV Plugins API](https://app.swaggerhub.com/apis/kalilistic/xiv-plugins-api)|REST API for dalamud and ACT plugins.


### PR DESCRIPTION
This PR adds **XIV Arbitrage** to both the Web Applications and Web APIs sections.

## Web Application
[XIV Arbitrage](https://xivarbitrage.projects.blueskye.co.uk/) scans ~10,000 marketable items across NA, EU, and OCE every 24 hours to find profitable cross-data-center price disparities and market bargains. It visualises DC average price differences with IQR-filtered stats, sale history charts, and discounted listings — filling a gap that no existing tool covers.

The source is open at [github.com/Flickwire-Agent/xivarbitrage](https://github.com/Flickwire-Agent/xivarbitrage).

## Web API
The public REST API at `/api/dc-disparities` and `/api/bargains` returns JSON with item details, pagination, and cache headers. It also exposes item sale history (`/api/items/:id/history`) and discounted listings (`/api/items/:id/listings`), plus a [full OpenAPI spec](https://xivarbitrage.projects.blueskye.co.uk/api/openapi.json) and usage monitoring at `/api/monitoring/usage`.

Combined with the [AI agent docs](https://xivarbitrage.projects.blueskye.co.uk/llms.txt), the API is designed to be easy for other tools and agents to consume — following the ecosystem-building pattern that has made Universalis so successful.