### PR TITLE
Add XIV Profitability to Web Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Name|Description
 [XIVStatus](https://xivstatus.com/)|FFXIV server status monitor.
 [xivsim](https://www.xivsim.com/)|FFXIV Raid Simulator.
 [XIV Plugins](https://xivplugins.com/)|Lists of most (all?) Dalamud and ACT plugins.
+[XIV Profitability](https://xivprofitability.com/)|Ranks the most profitable crafts, gathering, monster drops, flips, and retainer ventures for your world using live market board prices.
 [XIV Recruit](https://www.xivrecruit.com/)|Search for a static or recruit members for your static that match your recruitment criteria (schedule, focus, mindset, etc.), including member management and more!
 [XIV ToDo](https://xivtodo.com/)|Completion trackers, dashboards, and daily & weekly activities.
 


### PR DESCRIPTION
Adds [XIV Profitability](https://xivprofitability.com/) to the Web Applications section (alphabetized, between XIV Plugins and XIV Recruit).

It's a free, no-account web tool that ranks the most profitable ways to make gil for the player's world — crafting, gathering, monster drops, NPC/cross-server flips, and retainer ventures — using live market board prices from Universalis. Works on desktop and mobile.

Thanks for maintaining this list!